### PR TITLE
refactored main.py to make it DRY

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,42 +1,53 @@
 from flask import Flask, request, redirect
 import streamlink
 import validators
-import sys
 
 app = Flask(__name__)
+
+
+def get_stream_obj(query):
+    try:
+        links = streamlink.streams(query)
+        qualities = list(links.keys())
+        return (links, qualities)
+    except Exception:
+        return f"Could not get the link, Streamlink couldn't read {query}"
+
 
 @app.route("/")
 def index():
     return "This program permits you to get direct access to streams by using Streamlink. Alternative link : https://iptv--iptv.repl.co/streamlink?url=*insert url*. Enjoy ! LaneSh4d0w."
 
-@app.route('/iptv-query')
-def home():
-  if request.args:
-    if request.args.get('streaming-ip') == "" :
-      return "No streaming IP found : reason = query string is empty"
-    else:
-      valid=validators.url(request.args.get('streaming-ip'));
-      if valid == True:
-        if "quality" in request.args:
-          if request.args.get("quality") == "unsure":
-            try:
-              stream_qualities = streamlink.streams(request.args.get('streaming-ip'))
-              sorted_list = list(stream_qualities.keys())
-              string_of_the_list = ', '.join(sorted_list)
-              return ("Available qualities = " + string_of_the_list)
-            except:
-              return ("Could not get the link, Streamlink couldn't read ", request.args.get('streaming-ip'))
-          else:    
-            return redirect(streamlink.streams(request.args.get('streaming-ip'))[request.args.get('quality')].url)
-        else:
-          return redirect(streamlink.streams(request.args.get('streaming-ip'))['best'].url)
-      else:
-        return "The URL you've entered is not valid."
-  else:
-    return "You provided nothing to me."
 
-if __name__ == '__main__':
-  app.run(
-    host='0.0.0.0',
-    port=8888
-  )
+@app.route("/iptv-query")
+def home():
+    if request.args:
+        query = request.args.get("streaming-ip")
+        if not query:
+            return "No streaming IP found. Reason: streaming-ip string is empty"
+
+        valid = validators.url(query)
+        if not valid:
+            return "The URL you've entered is not valid."
+
+        # get stream data or exit with error message
+        stream_obj = get_stream_obj(query)
+        if type(stream_obj) == str:
+            return stream_obj
+
+        # Use specified quality or "best"
+        quality = request.args.get("quality")
+        if not quality:
+            return redirect(stream_obj[0]["best"].url)
+        elif quality in stream_obj[1]:
+            return redirect(stream_obj[0][quality].url)
+        else:
+            # if quality invalid, list available qualities
+            qualities = ",".join(stream_obj[1])
+            return f"Available qualities are: {qualities}"
+    else:
+        return "You provided nothing to me."
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8888)


### PR DESCRIPTION
### Changes
The line `streamlink.streams(request.args.get('streaming-ip')` was repeated several times throughout the code. I corrected this by creating a function and that does the query and stores response a variable. I am not sure if `streamlink.streams()` queries the host each time it is called or if the initial response is cached by python. If the former is true, then the refactor reduces the number of queries to the host to just one per request. This would help in reducing the chance of getting a 429 error from the host.   
### New
Another change made, is how the server handles quality queries. If a valid quality string is provided, a matching link is served. Otherwise the list of valid qualities is served. This means that any quality query string that does not match any available quality, including the previous `unsure`, will return the list.  
Tests performed on the old and new code show performance parity with the refactored code pulling ahead in some cases.  
### Proposal
On the subject of quality queries, I propose adding an option to serve multiple quality links per request if more than one quality is passed.