### PR TITLE
Added exception handling for streamlink errors

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -4,8 +4,9 @@ import streamlink
 class Fetch:
     """
         Gets data from host, filters it and returns streams
+        (query: str, quality: str,list,tuple)
     """
-    def __init__(self, query, quality="best"):
+    def __init__(self, query, quality):
         self.query = query
         if not quality:
             quality = "best"
@@ -15,16 +16,24 @@ class Fetch:
             self.qualities = [quality]
 
     def get_streams(self):
+        """
+            Get data streams and resolutions
+            Returns: (links, resolution), Error string
+        """
         try:
             # FIXME has issues if a channel is hosting another on Twitch
             links = streamlink.streams(self.query)
-            print(links)
             res = list(links.keys())
             return (links, res)
         except Exception:
             return 1
 
     def filtered_streams(self):
+        """
+            Filter streams according to specified quality.
+            Default quality: best
+            Returns: {quality: stream_url}
+        """
         try:
             streams, resolutions = self.get_streams()
             if not streams:

--- a/api/api.py
+++ b/api/api.py
@@ -1,11 +1,19 @@
 import streamlink
+from streamlink import (
+    StreamError,
+    StreamlinkError,
+    PluginError,
+    NoPluginError,
+    NoStreamsError,
+)
 
 
 class Fetch:
     """
-        Gets data from host, filters it and returns streams
-        (query: str, quality: str,list,tuple)
+    Gets data from host, filters it and returns streams
+    (query: str, quality: str,list,tuple)
     """
+
     def __init__(self, query, quality):
         self.query = query
         if not quality:
@@ -17,8 +25,8 @@ class Fetch:
 
     def get_streams(self):
         """
-            Get data streams and resolutions
-            Returns: (links, resolution), Error string
+        Get data streams and resolutions
+        Returns: (links, resolution), Error string
         """
         try:
             # FIXME has issues if a channel is hosting another on Twitch
@@ -26,21 +34,27 @@ class Fetch:
             res = list(links.keys())
             return (links, res)
         except Exception:
-            return 1
+            # returnes exceptions raised by streamlink
+            raise
 
     def filtered_streams(self):
         """
-            Filter streams according to specified quality.
-            Default quality: best
-            Returns: {quality: stream_url}
+        Filter streams according to specified quality.
+        Default quality: best
+        Returns: {quality: stream_url}
         """
         try:
-            streams, resolutions = self.get_streams()
+            payload = self.get_streams()
+            streams, resolutions = payload
             if not streams:
                 raise ValueError
             res_str = ",".join(resolutions)
+        except PluginError as pe:
+            return str(pe)
         except ValueError:
             return f"Could not get the link, Streamlink couldn't read {self.query}"
+        except TypeError:
+            return payload
 
         # TODO: find a more elegant solution to deal with 'best' and 'worst'
         if "best" in self.qualities:

--- a/api/main.py
+++ b/api/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 from flask import Flask, request, redirect, send_file
 import validators
 from api import Fetch
@@ -64,8 +65,9 @@ def query_hanlder(args, api):
             return api_formated(message, api)
 
         quality = args.get("quality")
-        stream_obj = Fetch(query, quality).filtered_streams()
-        return api_formated(stream_obj, api, query)
+        stream_obj = Fetch(query, quality)
+        streams = stream_obj.filtered_streams()
+        return api_formated(streams, api, query)
     else:
         message = "No queries provided. Nothing to do."
         return api_formated(message, api)


### PR DESCRIPTION
In response to this discussion comment, https://github.com/LaneSh4d0w/query-streamlink/pull/2#issuecomment-877650543 I am making a pull request to catch streamlink exceptions to get more meaningful error messages. You can test youtube live streams with it to see if you get the errors.