### PR TITLE
Add Heroku Deploy Button

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -31,6 +31,9 @@ Basically any website that [Streamlink](https://streamlink.github.io/plugin_matr
 
 - quality (optional) : The streaming quality you want to watch in. No quality specified results in automatically choosing the best quality available for this stream. Specifying "unsure" gives you all the available qualities for the stream.
 
+## Deploy to Heroku
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https%3A%2F%2Fgithub.com%2FLaneSh4d0w%2Fquery-streamlink)
+
 ## Thank yous :
 
 -  [@keystroke3](https://github.com/keystroke3) for the support and rework of the application.

--- a/README-es.md
+++ b/README-es.md
@@ -32,6 +32,10 @@ streaming-ip (obligatorio) : La URL del stream que quiere ver.
 
 quality (opcional): La calidad del stream en cualquier quieres verlo. No calidad especificada va a escoger la mejor calidad disponible. Especificar "unsure" va a mostrar todas las calidades disponibles.
 
+## Desplegar en Heroku
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https%3A%2F%2Fgithub.com%2FLaneSh4d0w%2Fquery-streamlink)
+
+
 ## Gracias:
 
 -  [@keystroke3](https://github.com/keystroke3) por el soporte y el rehacimiento de la aplicación.

--- a/README-fr.md
+++ b/README-fr.md
@@ -32,6 +32,9 @@ streaming-ip (obligatoire) : L'URL du site dont vous souhaitez le flux vidéo.
 
 quality (optionnel) : La qualité voulue pour ce flux. Ne pas renseigner la qualité revient à choisir la meilleure, renseigner "unsure" revient à donner toutes les qualités disponibles pour ce flux.
 
+## Déployer sur Heroku
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://dashboard.heroku.com/new?template=https%3A%2F%2Fgithub.com%2FLaneSh4d0w%2Fquery-streamlink)
+
 ## Remerciements :
 
 -  [@keystroke3](https://github.com/keystroke3) pour la refonte du programme, et de la création de l'API.

--- a/app.json
+++ b/app.json
@@ -1,0 +1,6 @@
+{
+   "name":"Query Streamlink",
+   "description":"A Python webapp that is destined to spit out links given by all sources supported by Streamlink. ",
+   "repository":"https://github.com/LaneSh4d0w/query-streamlink",
+   "logo":"https://streamlink.github.io/_static/icon.svg"
+}


### PR DESCRIPTION
I've added a button to the README files so we can quickly deploy the app to Heroku. I have also added the "app.json" file, necessary for the button to work.